### PR TITLE
link citation to preferred DOI resolver

### DIFF
--- a/app/models/concerns/citeable.rb
+++ b/app/models/concerns/citeable.rb
@@ -4,7 +4,7 @@ module Citeable
 
   def citation_html_url
     return nil if self.doi.blank?
-    "http://dx.doi.org/#{self.doi}"
+    "https://doi.org/#{self.doi}"
   end
 
   def doi_badge


### PR DESCRIPTION
Hello!

The DOI foundation recommends a [new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8).

Cheers :-)